### PR TITLE
completing column parallel, first QKV attempt

### DIFF
--- a/scratchpad/managers/toppings_manager.py
+++ b/scratchpad/managers/toppings_manager.py
@@ -207,27 +207,18 @@ class ToppingsManager:
             if "qkv_proj" not in module_name:
                 weight_name = self.get_weight_name(module_name, 0)
                 module.set_topping_info(
-                    self.A_buffer[weight_name][layer_id],
-                    self.B_buffer[weight_name][layer_id],
                     bs,
                     weight_indices,
-                    torch.zeros(0,0,0),
-                    torch.zeros(0,0,0),
-                    torch.zeros(0,0,0)
+                    lora_buffer = (self.A_buffer[weight_name][layer_id], self.B_buffer[weight_name][layer_id]),
+                    delta_buffer = None
                 )
             else:
                 module.set_topping_info(
-                    self.A_buffer["qkv_proj"][layer_id],
-                    self.B_buffer["q_proj"][layer_id],
-                    self.B_buffer["kv_proj"][layer_id],
                     bs,
                     weight_indices,
-                    torch.zeros(0,0,0),
-                    torch.zeros(0,0,0),
-                    torch.zeros(0,0,0),
-                    torch.zeros(0,0,0),
-                    torch.zeros(0,0,0),
-                    torch.zeros(0,0,0)
+                    lora_buffer = (self.A_buffer["qkv_proj"][layer_id], self.B_buffer["q_proj"][layer_id], self.B_buffer["kv_proj"][layer_id]),
+                    delta_kv_buffer = None,
+                    delta_q_buffer = None                    
                 )
 
     def register_topping(


### PR DESCRIPTION
Assumptions for lora:
currently assuming that arguments arrive in shapes: A _(batch_size, input_dim, rank*2)_, B _(batch_size, rank, input_dim*2)_
**Question 1:** should we instead expect the transposed versions:  A _(batch_size, rank*2, input_dim)_, B _(batch_size,input_dim*2, rank)_

Assumptions for sbmm:
assuming that arguments arrive in shapes: q_weights (batch_size, _, _*2), meta (batch_size, _, _*2), scale(batch_size, _, _*2) 

**Question 2:** In general it might be beneficial to concatenate the weights in the first dimension rather than the last dimension, assuming that the weights are stored in row major order? eg. A _(batch_size*2, input_dim, rank)_ instead of A _(batch_size, input_dim, rank*2)_
